### PR TITLE
Force python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ### October 2020 update: 
 Version 1.2 released with performance improvements, better handling of sequencing artifacts, and some improvements to useability.
 
-### Oct 2020 update:
 We have revised the GRCh38 data repository and updated docker support. The new data repo for all supported reference genomes is available [here](https://drive.google.com/drive/folders/0ByYcg0axX7udeGFNVWtaUmxrOFk). A separate version of the data repo used for development purposes is [available here](https://drive.google.com/drive/folders/18T83A12CfipB0pnGsTs3s-Qqji6sSvCu). 
 
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ### Recent updates:
 
-### September 2020 update: 
+### October 2020 update: 
 Version 1.2 released with performance improvements, better handling of sequencing artifacts, and some improvements to useability.
 
 ### Oct 2020 update:
-We have revised the GRCh38 data repository and updated docker support. The new data repo for all supported reference genomes is available [here](https://drive.google.com/drive/folders/0ByYcg0axX7udeGFNVWtaUmxrOFk). 
+We have revised the GRCh38 data repository and updated docker support. The new data repo for all supported reference genomes is available [here](https://drive.google.com/drive/folders/0ByYcg0axX7udeGFNVWtaUmxrOFk). A separate version of the data repo used for development purposes is [available here](https://drive.google.com/drive/folders/18T83A12CfipB0pnGsTs3s-Qqji6sSvCu). 
 
 
 ## Introduction

--- a/src/AmpliconArchitect.py
+++ b/src/AmpliconArchitect.py
@@ -41,7 +41,11 @@ import logging
 #plt.rc('text', usetex=True)
 #plt.rc('font', family='serif')
 
-if (sys.version_info < (3, 0)):
+if sys.version_info >= (3,0):
+    sys.stderr.write("AA must be run with python2. Python3 support is under development.\n")
+    sys.exit(1)
+
+else sys.version_info < (3, 0):
     from sets import Set
 
 import global_names

--- a/src/amplified_intervals.py
+++ b/src/amplified_intervals.py
@@ -32,6 +32,9 @@ import os
 import pysam
 import global_names
 
+if sys.version_info >= (3,0):
+    sys.stderr.write("AA must be run with python2. Python3 support is under development.\n")
+    sys.exit(1)
 
 GAIN = 5.0
 CNSIZE_MIN = 100000


### PR DESCRIPTION
Since Ubuntu 20.04 uses python3 as default python, and AA crashes in a non-obvious way when python3 is used, this checks the python version and exits (status 1) if the version is > 2.

Also, minor tweak the the AA readme. In the "update" section I kept your data repo link, but also added a link to my "development" data repo there so that going forward it is easier for us to merge between our forks without needing to replace URLs.
